### PR TITLE
fix: Correct the setting of public and private views and paths from router and App.vue.

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -17,19 +17,22 @@ onBeforeMount(async () => {
   if (authStore.isAuthenticated) {
     await userStore.init();
 
-    if (userStore.currentUser?.role == "client") {
-      if (route.name == "process_form" || route.name == "directory_list") {
-        router.push({
-          name: "process_list",
-          params: {
-            user_id: "",
-            display: "",
-          },
-        });
-      }
+    // If the user role is "client" and is on restricted routes, redirect to "process_list"
+    if (userStore.currentUser?.role === "client" && 
+        (route.name === "process_form" || route.name === "directory_list")) {
+      router.push({
+        name: "process_list",
+        params: {
+          user_id: "",
+          display: "",
+        },
+      });
     }
   } else {
-    router.push({ name: "sign_in" });
+    // Redirect to "sign_in" only if the route requires authentication
+    if (route.meta.requiresAuth) {
+      router.push({ name: "sign_in" });
+    }
   }
 });
 </script>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -2,7 +2,6 @@ import { useAuthStore } from "@/stores/auth";
 import { createRouter, createWebHistory } from "vue-router";
 import SlideBar from '@/components/layouts/SlideBar.vue';
 
-// Define the routes for the application
 const router = createRouter({
   history: createWebHistory(),
   routes: [
@@ -10,26 +9,31 @@ const router = createRouter({
       path: "/",
       name: "sign_in",
       component: () => import("@/views/auth/SignIn.vue"),
+      meta: { requiresAuth: false },
     },
     {
       path: "/sign_on",
       name: "sign_on",
       component: () => import("@/views/auth/SignOn.vue"),
+      meta: { requiresAuth: false },
     },
     {
       path: "/forget_password",
       name: "forget_password",
       component: () => import("@/views/auth/ForgetPassword.vue"),
+      meta: { requiresAuth: false },
     },
     {
       path: "/policies/privacy_policy",
       name: "privacy_policy",
       component: () => import("@/views/policies/PrivacyPolicy.vue"),
+      meta: { requiresAuth: false },
     },
     {
       path: "/policies/terms_of_use",
       name: "terms_of_use",
       component: () => import("@/views/policies/TermsOfUse.vue"),
+      meta: { requiresAuth: false },
     },
     {
       path: "/process_list/:user_id?/:display?",
@@ -38,7 +42,8 @@ const router = createRouter({
         {
           path: '',
           name: "process_list",
-          component: () => import("@/views/process/ProcessList.vue")
+          component: () => import("@/views/process/ProcessList.vue"),
+          meta: { requiresAuth: true },
         },
       ],
     },
@@ -50,6 +55,7 @@ const router = createRouter({
           path: '',
           name: "process_detail",
           component: () => import("@/views/process/ProcessDetail.vue"),
+          meta: { requiresAuth: true },
         },
       ],
     },
@@ -61,6 +67,7 @@ const router = createRouter({
           path: '',
           name: "process_form",
           component: () => import("@/views/process/ProcessForm.vue"),
+          meta: { requiresAuth: true },
         },
       ],
     },
@@ -72,21 +79,27 @@ const router = createRouter({
           path: '',
           name: "directory_list",
           component: () => import("@/views/directory/DirectoryList.vue"),
+          meta: { requiresAuth: true },
         },
       ],
     },
   ],
+  scrollBehavior() {
+    return { top: 0 };
+  },
 });
 
 // Navigation guard to check for authentication
 router.beforeEach((to, from, next) => {
   const authStore = useAuthStore();
+
+  // Check if the route requires authentication
   if (to.meta.requiresAuth && !authStore.isAuthenticated) {
-    next("/"); // Redirect to home if not authenticated
+    next({ name: "sign_in" });
   } else {
-    next(); // Proceed to the route
+    next();
   }
 });
 
-export default router; // Export the router instance
-export const routes = router.options.routes; // Export the routes array
+export default router;
+export const routes = router.options.routes;


### PR DESCRIPTION
# PR Description: Route Guard and Redirect Fixes for Public and Authenticated Routes

### Overview
This PR addresses an issue where all routes were redirecting to the `sign_in` page, even for publicly accessible routes. It refines the redirection logic to ensure proper access control, allowing public routes to be accessible without authentication while protecting restricted routes.

### Changes Made
1. **Router Guard Adjustment**: Updated the router guard in `App.vue` to check if the route requires authentication before redirecting. Now, it only redirects to `sign_in` when the `requiresAuth` meta field is `true` and the user is not authenticated.
   
2. **Conditional Redirection for Client Role**:
   - If the user is authenticated and their role is "client," they are redirected to `process_list` if they attempt to access restricted views (`process_form` or `directory_list`).
   
3. **Refactoring in `App.vue`**:
   - Added specific conditions within `onBeforeMount` to ensure that only protected routes trigger authentication checks.
   - Removed redundant redirections, making public routes (e.g., `sign_on`, `privacy_policy`, `terms_of_use`) fully accessible.

### Testing
1. Verified that public routes (`sign_on`, `forget_password`, `policies`) are accessible without redirecting to `sign_in`.
2. Confirmed that restricted routes properly redirect to `sign_in` when accessed without authentication.
3. Tested the `client` role redirection to `process_list` when accessing `process_form` and `directory_list`.

### Additional Notes
This update improves navigation behavior and provides a seamless experience for both authenticated and unauthenticated users, ensuring correct access to restricted routes based on user roles.
