### PR TITLE
chore: Add No Connection view for no connection time.

### DIFF
--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -36,6 +36,12 @@ const router = createRouter({
       meta: { requiresAuth: false },
     },
     {
+      path: "/no_connection",
+      name: "no_connection",
+      component: () => import("@/views/offline/NoConnection.vue"),
+      meta: { requiresAuth: false },
+    },
+    {
       path: "/process_list/:user_id?/:display?",
       component: SlideBar,
       children: [

--- a/frontend/src/views/offline/NoConnection.vue
+++ b/frontend/src/views/offline/NoConnection.vue
@@ -1,0 +1,13 @@
+<template>
+    <div class="bg-selected-background w-screen h-screen flex justify-center items-center">
+        <div class="flex flex-col items-center justify-center space-y-2 text-center">
+            <GlobeAmericasIcon class="w-40 h-40 text-primary"></GlobeAmericasIcon>
+            <h1 class="text-4xl text-primary font-semibold">¡Parece que no hay internet!</h1>
+            <p class="text-xl text-gray-500 font-regular">Revisa tu conexión para seguir navegando.</p>
+        </div>
+    </div>
+</template>
+
+<script setup>
+import {GlobeAmericasIcon} from '@heroicons/vue/24/outline';
+</script>

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -37,6 +37,23 @@ export default defineConfig({
             type: 'image/png'
           }
         ]
+      },
+      workbox: {
+        navigateFallback: '/static/frontend/index.html',
+        globPatterns: ['**/*.{js,css,png,jpg,svg,webp,woff2,woff}'],
+        runtimeCaching: [
+          {
+            urlPattern: /\/no_connection$/,
+            handler: 'NetworkOnly',
+            options: {
+              cacheName: 'offline-page',
+              expiration: {
+                maxEntries: 1,
+                maxAgeSeconds: 7 * 24 * 60 * 60,
+              },
+            },
+          },
+        ],
       }
     })
   ],


### PR DESCRIPTION
- Implemented an offline fallback route in the Vue router (`/no-connection`) to display a custom "No Connection" page when the user is offline.
- Configured `vite.config.js` with Workbox to pre-cache all necessary assets (JavaScript, CSS, images, fonts) to ensure the PWA functions offline.
- Set up `navigateFallback` to redirect all failed requests to `index.html`, allowing the Vue router to handle offline routing.
- Added runtime caching for the `/no-connection` route to ensure it loads even if the user hasn't accessed it before.
- Verified offline behavior for initial access without a prior visit to the `/no-connection` page.