### PR TITLE
fix: make verification code email readable in dark mode and add plain-text fallback

### DIFF
--- a/backend/gym_app/templates/emails/code_verification/code_verification.html
+++ b/backend/gym_app/templates/emails/code_verification/code_verification.html
@@ -35,7 +35,7 @@
                         <tr>
                           <td align="left" style="font-size:0px;padding:0 0 15px;word-break:break-word;">
                             <div style="font-family:Inter, Arial, sans-serif;font-size:15px;font-weight:400;line-height:1.5;text-align:left;color:#374151;">
-                              Has solicitado un código de verificación para acceder a los servicios de <strong>G&M Consultores Jurídicos</strong>. Por favor, utiliza el siguiente código para completar tu proceso de registro:
+                              Has solicitado un código de verificación para acceder a los servicios de <strong>G&M Consultores Jurídicos</strong>. Por favor, utiliza el siguiente código para completar tu proceso de registro: <strong style="color:#374151;">{{passcode}}</strong>
                             </div>
                           </td>
                         </tr>
@@ -43,10 +43,12 @@
                         <!-- Verification Code Box -->
                         <tr>
                           <td style="padding:10px 20px;">
-                            <table role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%" bgcolor="#1e40af" style="background-color:#1e40af;background:#1e40af;background-image:linear-gradient(135deg,#1e40af 0%,#3b82f6 100%);border-radius:12px;margin:20px auto;">
+                            <!-- Dark text on light background survives dark-mode color inversion;
+                                 white-on-dark-blue rendered invisible in inverted clients -->
+                            <table role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%" bgcolor="#eff6ff" style="background-color:#eff6ff;background:#eff6ff;border:2px solid #1e40af;border-radius:12px;margin:20px auto;">
                               <tr>
-                                <td align="center" bgcolor="#1e40af" style="background-color:#1e40af;padding:20px 15px;border-radius:12px;">
-                                  <div style="font-size:28px;font-weight:700;color:#ffffff;letter-spacing:4px;font-family:'Courier New',monospace;text-shadow:0 0 2px #1e3a8a,0 1px 2px rgba(0,0,0,0.5);word-break:break-all;line-height:1.2;">{{passcode}}</div>
+                                <td align="center" bgcolor="#eff6ff" style="background-color:#eff6ff;padding:20px 15px;border-radius:12px;">
+                                  <div style="font-size:28px;font-weight:700;color:#1e40af;letter-spacing:4px;font-family:'Courier New',monospace;word-break:break-all;line-height:1.2;">{{passcode}}</div>
                                 </td>
                               </tr>
                             </table>

--- a/backend/gym_app/templates/emails/layout/layout.html
+++ b/backend/gym_app/templates/emails/layout/layout.html
@@ -111,10 +111,11 @@
       color: #1e40af;
       line-height: 1.4;
     }
+    /* Dark text on light background survives dark-mode color inversion */
     .verification-code {
-      background-color: #1e40af;
-      background: #1e40af;
-      background-image: linear-gradient(135deg, #1e40af 0%, #3b82f6 100%);
+      background-color: #eff6ff;
+      background: #eff6ff;
+      border: 2px solid #1e40af;
       border-radius: 12px;
       padding: 20px 15px;
       text-align: center;
@@ -125,10 +126,9 @@
     .code-text {
       font-size: 28px;
       font-weight: 700;
-      color: #ffffff;
+      color: #1e40af;
       letter-spacing: 4px;
       font-family: 'Courier New', monospace;
-      text-shadow: 0 0 2px #1e3a8a, 0 1px 2px rgba(0,0,0,0.5);
       word-break: break-all;
       line-height: 1.2;
     }

--- a/backend/gym_app/tests/views/test_send_email.py
+++ b/backend/gym_app/tests/views/test_send_email.py
@@ -62,7 +62,7 @@ def test_send_template_email_skips_missing_attachments():
     email_instance.attach_file.side_effect = [FileNotFoundError(), None]
 
     with patch('gym_app.views.layouts.sendEmail.get_template', side_effect=[layout_template, content_template]), patch(
-        'gym_app.views.layouts.sendEmail.EmailMessage', return_value=email_instance
+        'gym_app.views.layouts.sendEmail.EmailMultiAlternatives', return_value=email_instance
     ):
         send_template_email(
             template_name='send_files',

--- a/backend/gym_app/views/dynamic_documents/signature_views.py
+++ b/backend/gym_app/views/dynamic_documents/signature_views.py
@@ -47,7 +47,7 @@ from PyPDF2 import PdfReader, PdfWriter
 from bs4 import BeautifulSoup
 from xhtml2pdf import pisa
 from reportlab.pdfgen import canvas
-from gym_app.views.layouts.sendEmail import EmailMessage
+from django.core.mail import EmailMessage
 import hashlib
 import base64
 from cryptography.hazmat.primitives.asymmetric import rsa, padding

--- a/backend/gym_app/views/layouts/sendEmail.py
+++ b/backend/gym_app/views/layouts/sendEmail.py
@@ -2,7 +2,7 @@ from rest_framework.response import Response
 from rest_framework import status
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import IsAuthenticated
-from django.core.mail import EmailMessage
+from django.core.mail import EmailMultiAlternatives
 from django.conf import settings
 from django.template.loader import get_template
 from django.utils.html import strip_tags
@@ -79,15 +79,17 @@ def send_template_email(template_name: str,
     html_content = layout_template.render(layout_context)
     plain_content = strip_tags(html_content)
 
-    email_message = EmailMessage(
+    # Plain-text body + HTML alternative so clients that strip or skip HTML
+    # still show the message content (e.g. verification codes)
+    email_message = EmailMultiAlternatives(
         subject=subject,
-        body=html_content,
+        body=plain_content,
         from_email=from_email or settings.DEFAULT_FROM_EMAIL,
         to=to_emails,
         cc=cc,
         bcc=bcc,
     )
-    email_message.content_subtype = "html"  # Indicate HTML body
+    email_message.attach_alternative(html_content, "text/html")
 
     # Attach files if provided
     for file_path in attachments:


### PR DESCRIPTION
## Summary

A user reported that the registration email arrives but the 6-digit verification code is invisible (blank/transparent). Root cause: dark-mode color inversion in email clients washes out white text on the dark blue code box, and the email was sent HTML-only (the plain-text body was computed but never used).

- Render the code as dark blue text on a light background with a blue border — survives dark-mode inversion; drop the gradient and text-shadow
- Repeat the code inline in the body paragraph as regular text as redundancy
- Send via `EmailMultiAlternatives` with a plain-text body plus HTML alternative (the previously dead `plain_content`)
- Import `EmailMessage` directly from `django.core.mail` in `signature_views.py` instead of through `sendEmail`'s removed re-export

## Test plan

- `pytest gym_app/tests/views/test_send_email.py` — 38 passed
- `pytest gym_app/tests/views/test_user_auth.py` — 29 passed
- `pytest gym_app/tests/views/test_signature_views_helpers.py` — 38 passed
- Real test email sent to an external Gmail account with the fixed template for light/dark mode visual verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)