### PR TITLE
chore(skills): tighten human skill — conclusion-first, tables-by-default

### DIFF
--- a/.agents/skills/human/SKILL.md
+++ b/.agents/skills/human/SKILL.md
@@ -1,59 +1,31 @@
 ---
 name: human
-description: "Responde con estructura escaneable (tablas, listas, categorias) — concisa, precisa, con jerga tecnica cuando aporta. Siempre en espanol."
+description: "Respuesta puntual y escaneable: conclusión primero, tablas/listas por default, cero relleno. Siempre en español."
 ---
 
-## Que produce
+## Objetivo
 
-Respuesta optimizada para escaneo visual. El operador lee la primera fila de cada tabla, el primer bullet de cada lista, y captura el 80% del contenido en 10 segundos. La profundidad esta en el detalle; la jerarquia, en la estructura.
+Respuesta escaneable en 10 segundos: la primera línea es la conclusión; el resto, tablas y listas. Cero relleno.
 
-## Reglas de formato
+## Reglas duras
 
-| Cuando usar           | Que usar              | Por que                              |
-|-----------------------|-----------------------|--------------------------------------|
-| Comparar 3+ items     | Tabla markdown        | Lectura cruzada en una vista         |
-| Pasos con orden       | Lista numerada        | Implica secuencia                    |
-| Items sin orden       | Bullets `-`           | Mas escaneable que prosa             |
-| Categorias tematicas  | Headers `### ` cortos | Permite saltar a la seccion          |
-| Codigo, path, comando | `code`                | Distinguir lo ejecutable             |
-| Estado por item       | Emoji ✅⚠️❌🚫        | Captura en 1 caracter                |
+1. **Primera línea = conclusión / estado / acción.** Sin preámbulos ("Claro, aquí tienes…").
+2. **Tabla o lista por default.** Prosa solo para 1-2 datos sueltos; nunca párrafos de 3+ líneas.
+3. **Cada dato vive en UN solo lugar** — no repetir en prosa lo que ya está en tabla.
+4. **Tope ~15 líneas visibles**, salvo que el operador pida detalle explícito.
+5. **Sin cierre-resumen** ni cortesías. Si la estructura es buena, sobra.
 
-## Anti-patrones (NO hacer)
+## Formato por tipo de dato
 
-- ❌ Parrafos de 4+ lineas de prosa cuando una tabla los reemplaza.
-- ❌ Headers tipo "Phase 1:", "Step 2:". Categorizar por **tema**, no por orden.
-- ❌ Repetir el dato en prosa y luego en tabla. Solo tabla.
-- ❌ Evitar jerga tecnica si es el termino correcto (e.g. `kernel`, `rebase`, `merge`).
-- ❌ Cerrar con resumen que repita lo de arriba. Si la estructura es buena, sobra.
-
-## Permisos explicitos
-
-- ✅ Citar rutas de archivo (`path/to/file.py:42`) si ayudan a localizar.
-- ✅ Comandos shell literales (`bash script.sh --apply`), sin parafrasear.
-- ✅ Fingerprints, hashes, IDs cuando son evidencia concreta.
-- ✅ Nombres tecnicos en ingles cuando son los oficiales (`staging`, `lifecycle`, `chmod 600`).
-- ✅ Explicar termino tecnico inline solo si no es trivial (e.g. "rebase (reescribir historia local)").
-
-## Estructura sugerida
-
-```
-[Una linea inicial con la conclusion / accion / estado.]
-
-## Categoria 1
-| col | col |
-|-----|-----|
-| ... | ... |
-
-## Categoria 2
-- bullet con info densa
-- bullet con info densa
-
-## Decisiones pendientes / next steps (si aplica)
-- accion concreta + responsable
-```
-
-No todas las respuestas necesitan las 3 secciones — escalar segun el contenido.
+| Dato | Formato |
+|---|---|
+| Comparación de 3+ items | Tabla markdown |
+| Pasos con orden | Lista numerada |
+| Items sueltos | Bullets `-` |
+| Estado por item | Emoji ✅⚠️❌🚫 |
+| Código / path / comando | `code` literal, sin parafrasear (`file.py:42`, hashes, IDs) |
+| Temas saltables | Headers `##` cortos por tema (nunca "Paso 1 / Fase 2") |
 
 ## Idioma
 
-Espanol. Terminos tecnicos en ingles cuando son los nombres canonicos (`commit`, `rebase`, `lifecycle`, `staging`, `chmod`). Definicion inline solo si el termino no es obvio.
+Español. Términos técnicos en inglés cuando son los canónicos (`commit`, `rebase`, `staging`, `chmod`); definición inline solo si no es obvio.

--- a/.agents/skills/human/agents/openai.yaml
+++ b/.agents/skills/human/agents/openai.yaml
@@ -1,5 +1,5 @@
 interface:
   display_name: "Human"
-  short_description: "Responde en espanol con estructura escaneable (tablas, listas, categorias)."
+  short_description: "Respuesta puntual en espanol: conclusion primero, tablas/listas por default, cero relleno."
 policy:
   allow_implicit_invocation: true

--- a/.claude/skills/human/SKILL.md
+++ b/.claude/skills/human/SKILL.md
@@ -1,63 +1,35 @@
 ---
 name: human
-description: "Responde con estructura escaneable (tablas, listas, categorias) — concisa, precisa, con jerga tecnica cuando aporta. Siempre en espanol."
+description: "Respuesta puntual y escaneable: conclusión primero, tablas/listas por default, cero relleno. Siempre en español."
 argument-hint: "[topic or question]"
 ---
 
-## Que produce
+## Objetivo
 
-Respuesta optimizada para escaneo visual. El operador lee la primera fila de cada tabla, el primer bullet de cada lista, y captura el 80% del contenido en 10 segundos. La profundidad esta en el detalle; la jerarquia, en la estructura.
+Respuesta escaneable en 10 segundos: la primera línea es la conclusión; el resto, tablas y listas. Cero relleno.
 
-## Reglas de formato
+## Reglas duras
 
-| Cuando usar           | Que usar              | Por que                              |
-|-----------------------|-----------------------|--------------------------------------|
-| Comparar 3+ items     | Tabla markdown        | Lectura cruzada en una vista         |
-| Pasos con orden       | Lista numerada        | Implica secuencia                    |
-| Items sin orden       | Bullets `-`           | Mas escaneable que prosa             |
-| Categorias tematicas  | Headers `### ` cortos | Permite saltar a la seccion          |
-| Codigo, path, comando | `code`                | Distinguir lo ejecutable             |
-| Estado por item       | Emoji ✅⚠️❌🚫        | Captura en 1 caracter                |
+1. **Primera línea = conclusión / estado / acción.** Sin preámbulos ("Claro, aquí tienes…").
+2. **Tabla o lista por default.** Prosa solo para 1-2 datos sueltos; nunca párrafos de 3+ líneas.
+3. **Cada dato vive en UN solo lugar** — no repetir en prosa lo que ya está en tabla.
+4. **Tope ~15 líneas visibles**, salvo que el operador pida detalle explícito.
+5. **Sin cierre-resumen** ni cortesías. Si la estructura es buena, sobra.
 
-## Anti-patrones (NO hacer)
+## Formato por tipo de dato
 
-- ❌ Parrafos de 4+ lineas de prosa cuando una tabla los reemplaza.
-- ❌ Headers tipo "Phase 1:", "Step 2:". Categorizar por **tema**, no por orden.
-- ❌ Repetir el dato en prosa y luego en tabla. Solo tabla.
-- ❌ Evitar jerga tecnica si es el termino correcto (e.g. `kernel`, `rebase`, `merge`).
-- ❌ Cerrar con resumen que repita lo de arriba. Si la estructura es buena, sobra.
-
-## Permisos explicitos
-
-- ✅ Citar rutas de archivo (`path/to/file.py:42`) si ayudan a localizar.
-- ✅ Comandos shell literales (`bash script.sh --apply`), sin parafrasear.
-- ✅ Fingerprints, hashes, IDs cuando son evidencia concreta.
-- ✅ Nombres tecnicos en ingles cuando son los oficiales (`staging`, `lifecycle`, `chmod 600`).
-- ✅ Explicar termino tecnico inline solo si no es trivial (e.g. "rebase (reescribir historia local)").
-
-## Estructura sugerida
-
-```
-[Una linea inicial con la conclusion / accion / estado.]
-
-## Categoria 1
-| col | col |
-|-----|-----|
-| ... | ... |
-
-## Categoria 2
-- bullet con info densa
-- bullet con info densa
-
-## Decisiones pendientes / next steps (si aplica)
-- accion concreta + responsable
-```
-
-No todas las respuestas necesitan las 3 secciones — escalar segun el contenido.
+| Dato | Formato |
+|---|---|
+| Comparación de 3+ items | Tabla markdown |
+| Pasos con orden | Lista numerada |
+| Items sueltos | Bullets `-` |
+| Estado por item | Emoji ✅⚠️❌🚫 |
+| Código / path / comando | `code` literal, sin parafrasear (`file.py:42`, hashes, IDs) |
+| Temas saltables | Headers `##` cortos por tema (nunca "Paso 1 / Fase 2") |
 
 ## Idioma
 
-Espanol. Terminos tecnicos en ingles cuando son los nombres canonicos (`commit`, `rebase`, `lifecycle`, `staging`, `chmod`). Definicion inline solo si el termino no es obvio.
+Español. Términos técnicos en inglés cuando son los canónicos (`commit`, `rebase`, `staging`, `chmod`); definición inline solo si no es obvio.
 
 ## Input
 

--- a/.windsurf/workflows/human.md
+++ b/.windsurf/workflows/human.md
@@ -1,58 +1,30 @@
 ---
-description: Responde con estructura escaneable (tablas, listas, categorias) — concisa, precisa, con jerga tecnica cuando aporta. Siempre en espanol.
+description: Respuesta puntual y escaneable — conclusión primero, tablas/listas por default, cero relleno. Siempre en español.
 ---
 
-## Que produce
+## Objetivo
 
-Respuesta optimizada para escaneo visual. El operador lee la primera fila de cada tabla, el primer bullet de cada lista, y captura el 80% del contenido en 10 segundos. La profundidad esta en el detalle; la jerarquia, en la estructura.
+Respuesta escaneable en 10 segundos: la primera línea es la conclusión; el resto, tablas y listas. Cero relleno.
 
-## Reglas de formato
+## Reglas duras
 
-| Cuando usar           | Que usar              | Por que                              |
-|-----------------------|-----------------------|--------------------------------------|
-| Comparar 3+ items     | Tabla markdown        | Lectura cruzada en una vista         |
-| Pasos con orden       | Lista numerada        | Implica secuencia                    |
-| Items sin orden       | Bullets `-`           | Mas escaneable que prosa             |
-| Categorias tematicas  | Headers `### ` cortos | Permite saltar a la seccion          |
-| Codigo, path, comando | `code`                | Distinguir lo ejecutable             |
-| Estado por item       | Emoji ✅⚠️❌🚫        | Captura en 1 caracter                |
+1. **Primera línea = conclusión / estado / acción.** Sin preámbulos ("Claro, aquí tienes…").
+2. **Tabla o lista por default.** Prosa solo para 1-2 datos sueltos; nunca párrafos de 3+ líneas.
+3. **Cada dato vive en UN solo lugar** — no repetir en prosa lo que ya está en tabla.
+4. **Tope ~15 líneas visibles**, salvo que el operador pida detalle explícito.
+5. **Sin cierre-resumen** ni cortesías. Si la estructura es buena, sobra.
 
-## Anti-patrones (NO hacer)
+## Formato por tipo de dato
 
-- ❌ Parrafos de 4+ lineas de prosa cuando una tabla los reemplaza.
-- ❌ Headers tipo "Phase 1:", "Step 2:". Categorizar por **tema**, no por orden.
-- ❌ Repetir el dato en prosa y luego en tabla. Solo tabla.
-- ❌ Evitar jerga tecnica si es el termino correcto (e.g. `kernel`, `rebase`, `merge`).
-- ❌ Cerrar con resumen que repita lo de arriba. Si la estructura es buena, sobra.
-
-## Permisos explicitos
-
-- ✅ Citar rutas de archivo (`path/to/file.py:42`) si ayudan a localizar.
-- ✅ Comandos shell literales (`bash script.sh --apply`), sin parafrasear.
-- ✅ Fingerprints, hashes, IDs cuando son evidencia concreta.
-- ✅ Nombres tecnicos en ingles cuando son los oficiales (`staging`, `lifecycle`, `chmod 600`).
-- ✅ Explicar termino tecnico inline solo si no es trivial (e.g. "rebase (reescribir historia local)").
-
-## Estructura sugerida
-
-```
-[Una linea inicial con la conclusion / accion / estado.]
-
-## Categoria 1
-| col | col |
-|-----|-----|
-| ... | ... |
-
-## Categoria 2
-- bullet con info densa
-- bullet con info densa
-
-## Decisiones pendientes / next steps (si aplica)
-- accion concreta + responsable
-```
-
-No todas las respuestas necesitan las 3 secciones — escalar segun el contenido.
+| Dato | Formato |
+|---|---|
+| Comparación de 3+ items | Tabla markdown |
+| Pasos con orden | Lista numerada |
+| Items sueltos | Bullets `-` |
+| Estado por item | Emoji ✅⚠️❌🚫 |
+| Código / path / comando | `code` literal, sin parafrasear (`file.py:42`, hashes, IDs) |
+| Temas saltables | Headers `##` cortos por tema (nunca "Paso 1 / Fase 2") |
 
 ## Idioma
 
-Espanol. Terminos tecnicos en ingles cuando son los nombres canonicos (`commit`, `rebase`, `lifecycle`, `staging`, `chmod`). Definicion inline solo si el termino no es obvio.
+Español. Términos técnicos en inglés cuando son los canónicos (`commit`, `rebase`, `staging`, `chmod`); definición inline solo si no es obvio.


### PR DESCRIPTION
Sync de la skill human reescrita (más puntual: conclusión primero, tablas/listas por default, tope ~15 líneas). Fuente: vps-ops-toolkit 909602e.